### PR TITLE
Refactor: Make get_open_interest return dict and update tests

### DIFF
--- a/open_interest_fetcher.py
+++ b/open_interest_fetcher.py
@@ -1,0 +1,73 @@
+import ccxt
+import requests # Adding requests for direct HTTP calls if ccxt doesn't support the v2 endpoint easily
+
+def get_open_interest(product_type: str) -> dict[str, str]:
+    """
+    Fetches the open interest for all symbols of a given product type from Bitget
+    and returns it as a dictionary.
+    Open interest is represented by the 'holdingAmount' field in the API response.
+    Returns an empty dictionary if data fetching fails or no data is found.
+    """
+    url = "https://api.bitget.com/api/v2/mix/market/tickers"
+    params = {"productType": product_type}
+    open_interest_data = {}
+
+    try:
+        response = requests.get(url, params=params)
+        response.raise_for_status()  # Raises an HTTPError for bad responses (4XX or 5XX)
+
+        data = response.json()
+
+        if data.get("code") == "00000" and "data" in data:
+            if not data["data"]:
+                # print(f"No open interest data found for product type: {product_type}") # Silenced for library use
+                return open_interest_data # Return empty dict
+
+            for ticker_data in data["data"]:
+                symbol = ticker_data.get("symbol")
+                holding_amount = ticker_data.get("holdingAmount")
+                if symbol and holding_amount is not None:
+                    open_interest_data[symbol] = holding_amount
+                # else:
+                    # print(f"  Incomplete data for one ticker: {ticker_data}") # Silenced for library use
+        else:
+            print(f"API error when fetching open interest for {product_type}: {data.get('msg', 'Unknown error')}")
+            return open_interest_data # Return empty dict on API error message
+
+    except requests.exceptions.HTTPError as e:
+        print(f"HTTP error fetching open interest for {product_type}: {e}")
+    except requests.exceptions.RequestException as e:
+        print(f"Network error fetching open interest for {product_type}: {e}")
+    except ValueError as e: # For JSON decoding errors
+        print(f"Error decoding JSON response for {product_type}: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred while fetching for {product_type}: {e}")
+
+    return open_interest_data
+
+if __name__ == "__main__":
+    # Example usage:
+    print("Fetching open interest for USDT-FUTURES...")
+    usdt_oi = get_open_interest("USDT-FUTURES")
+    if usdt_oi:
+        print(f"USDT-FUTURES Open Interest Data ({len(usdt_oi)} symbols):")
+        for symbol, oi in list(usdt_oi.items())[:5]: # Print first 5 for brevity
+            print(f"  Symbol: {symbol}, Open Interest: {oi}")
+    else:
+        print("No USDT-FUTURES open interest data returned or an error occurred.")
+
+    print("\nFetching open interest for COIN-FUTURES...")
+    coin_oi = get_open_interest("COIN-FUTURES")
+    if coin_oi:
+        print(f"COIN-FUTURES Open Interest Data ({len(coin_oi)} symbols):")
+        for symbol, oi in list(coin_oi.items())[:5]: # Print first 5 for brevity
+            print(f"  Symbol: {symbol}, Open Interest: {oi}")
+    else:
+        print("No COIN-FUTURES open interest data returned or an error occurred.")
+
+    print("\nFetching open interest for INVALID-FUTURES (expected empty or error)...")
+    invalid_oi = get_open_interest("INVALID-FUTURES")
+    if not invalid_oi:
+        print("Correctly received no data or an error for INVALID-FUTURES.")
+    else:
+        print(f"Unexpectedly received data for INVALID-FUTURES: {invalid_oi}")

--- a/open_interest_fetcher_test.py
+++ b/open_interest_fetcher_test.py
@@ -1,0 +1,93 @@
+import pytest
+from open_interest_fetcher import get_open_interest
+
+def test_get_open_interest_usdt_futures_live():
+    """
+    Tests get_open_interest with "USDT-FUTURES" using live data.
+    Checks that the function returns a non-empty dictionary with string keys and values.
+    """
+    product_type = "USDT-FUTURES"
+    print(f"Testing get_open_interest with product type: {product_type} (Live Data) - expecting dict")
+
+    result = get_open_interest(product_type)
+
+    assert isinstance(result, dict), "Result should be a dictionary."
+    assert len(result) > 0, "Result dictionary should not be empty for USDT-FUTURES."
+
+    # Check a few items to ensure structure
+    for symbol, holding_amount in result.items():
+        assert isinstance(symbol, str), "Symbol should be a string."
+        assert len(symbol) > 0, "Symbol string should not be empty."
+        assert isinstance(holding_amount, str), f"Holding amount for {symbol} should be a string."
+        # Try to convert holding_amount to float to ensure it's a numerical string
+        try:
+            float(holding_amount)
+        except ValueError:
+            pytest.fail(f"Holding amount '{holding_amount}' for symbol '{symbol}' is not a valid number string.")
+        break # Only need to check one item's structure for this test
+
+    print(f"Received {len(result)} symbols for {product_type}.")
+
+def test_get_open_interest_coin_futures_live():
+    """
+    Tests get_open_interest with "COIN-FUTURES" using live data.
+    Checks that the function returns a non-empty dictionary with string keys and values.
+    """
+    product_type = "COIN-FUTURES"
+    print(f"Testing get_open_interest with product type: {product_type} (Live Data) - expecting dict")
+
+    result = get_open_interest(product_type)
+
+    assert isinstance(result, dict), "Result should be a dictionary."
+    assert len(result) > 0, "Result dictionary should not be empty for COIN-FUTURES."
+
+    for symbol, holding_amount in result.items():
+        assert isinstance(symbol, str), "Symbol should be a string."
+        assert isinstance(holding_amount, str), f"Holding amount for {symbol} should be a string."
+        try:
+            float(holding_amount)
+        except ValueError:
+            pytest.fail(f"Holding amount '{holding_amount}' for symbol '{symbol}' is not a valid number string.")
+        break
+    print(f"Received {len(result)} symbols for {product_type}.")
+
+def test_get_open_interest_invalid_product_type_live(capsys):
+    """
+    Tests get_open_interest with an invalid product type.
+    Checks that it returns an empty dictionary and prints an HTTP error to console.
+    """
+    product_type = "INVALID-PRODUCT-TYPE"
+    print(f"Testing get_open_interest with product type: {product_type} (Live Data) - expecting empty dict and error print")
+
+    result = get_open_interest(product_type)
+
+    assert isinstance(result, dict), "Result should be a dictionary."
+    assert len(result) == 0, "Result dictionary should be empty for an invalid product type."
+
+    captured = capsys.readouterr()
+    assert f"HTTP error fetching open interest for {product_type}" in captured.out
+    assert "400 Client Error: Bad Request" in captured.out
+    print(f"Correctly received empty dict for {product_type}. Error printed: {captured.out.strip()}")
+
+def test_get_open_interest_empty_product_type_live(capsys):
+    """
+    Tests get_open_interest with an empty product type string.
+    Checks that it returns an empty dictionary and prints an HTTP error to console.
+    """
+    product_type = ""
+    print(f"Testing get_open_interest with product type: '{product_type}' (Live Data) - expecting empty dict and error print")
+
+    result = get_open_interest(product_type)
+
+    assert isinstance(result, dict), "Result should be a dictionary."
+    assert len(result) == 0, "Result dictionary should be empty for an empty product type."
+
+    captured = capsys.readouterr()
+    assert f"HTTP error fetching open interest for {product_type}" in captured.out
+    assert "400 Client Error: Bad Request" in captured.out
+    print(f"Correctly received empty dict for empty product type. Error printed: {captured.out.strip()}")
+
+# Note: As per AGENTS.MD: "when doing test use live data for better results do not mock data"
+# Therefore, no mocking is used here.
+# The `capsys` fixture is still used for error cases to check console output,
+# as the function is designed to print errors while returning an empty dict.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ccxt
 pytest
 pytest-cov
+requests


### PR DESCRIPTION
- Modified `get_open_interest` in `open_interest_fetcher.py` to return a dictionary of symbol-holdingAmount pairs instead of printing to stdout.
- The function now returns an empty dictionary in case of API errors, network issues, or if no data is found. Error messages are still printed to the console for these cases.
- Updated `open_interest_fetcher_test.py` to assert the dictionary output for successful calls and to verify an empty dictionary is returned on errors.
- Tests for error conditions continue to use `capsys` to ensure error messages are printed to the console as expected.
- All tests pass with these changes.